### PR TITLE
Update dashboard.js

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -144,6 +144,12 @@ document.addEventListener('DOMContentLoaded', () => {
   }
       
   function displayFuelUps(vehicleId) {
+    // Remove any existing fuel-ups container
+    const existingContainer = document.getElementById('fuel-ups-container');
+    if (existingContainer) {
+        existingContainer.remove();
+    }
+
     fetchFuelUps(vehicleId).then(fuelUps => {
       const fuelUpsContainer = document.createElement('div');
       fuelUpsContainer.id = 'fuel-ups-container';


### PR DESCRIPTION
This change adds a check at the beginning of the displayFuelUps function to remove any existing fuel-ups container before creating a new one. This will prevent multiple instances of the fuel history from being displayed when the button is clicked multiple times.