### PR TITLE
update date in chart

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -571,7 +571,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (days) {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - days);
-      filteredData = filteredData.filter(fu => new Date(fu.date) >= cutoffDate);
+      filteredData = filteredData.filter(fu => 
+        new Date(new Date(fu.date).toLocaleDateString('en-US', { timeZone: 'UTC' })) >= 
+        new Date(cutoffDate.toLocaleDateString('en-US', { timeZone: 'UTC' }))
+      );
     }
   
     const chartData = {


### PR DESCRIPTION
This change ensures that:
Both dates are compared using UTC timezone
Time portions of the dates are stripped away (by converting to LocaleDateString and back to Date) The comparison will match what's shown in your table This should eliminate the 1-day discrepancy you're seeing in the filtered results.